### PR TITLE
Handler简化

### DIFF
--- a/examples/custom_handler/Cargo.toml
+++ b/examples/custom_handler/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "example-custom_handler"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+silent = { path = "../../silent" }
+async-trait = "0.1.68"

--- a/examples/custom_handler/src/main.rs
+++ b/examples/custom_handler/src/main.rs
@@ -1,0 +1,44 @@
+use async_trait::async_trait;
+use silent::prelude::*;
+use std::sync::atomic::AtomicUsize;
+use std::sync::Arc;
+
+fn main() {
+    logger::fmt().with_max_level(Level::INFO).init();
+    let route = Route::new("").handler(
+        Method::GET,
+        Arc::new(CustomHandler {
+            count: AtomicUsize::new(0),
+        }),
+    );
+    Server::new().bind_route(route).run();
+}
+
+struct CustomHandler {
+    count: AtomicUsize,
+}
+
+#[async_trait]
+impl Handler for CustomHandler {
+    async fn call(&self, _req: Request) -> Result<Response> {
+        let html = r#"
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <title>custom handler</title>
+        </head>
+        <body>
+            <h1>custom handler</h1>
+            <p>count: "#
+            .to_string()
+            + &self
+                .count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                .to_string()
+            + r#"</p>
+        </body>
+        </html>"#;
+        Ok(html.into())
+    }
+}

--- a/examples/custom_response/Cargo.toml
+++ b/examples/custom_response/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "example-custom_response"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+silent = { path = "../../silent" }

--- a/examples/custom_response/src/main.rs
+++ b/examples/custom_response/src/main.rs
@@ -1,0 +1,47 @@
+use silent::prelude::*;
+
+fn main() {
+    logger::fmt().with_max_level(Level::INFO).init();
+    let route = Route::new("")
+        .handler(
+            Method::GET,
+            HandlerWrapperResponse::new(custom_response).arc(),
+        )
+        .append(Route::new("2").handler(
+            Method::GET,
+            HandlerWrapperResponse::new(custom_response2).arc(),
+        ));
+    Server::new().bind_route(route).run();
+}
+
+async fn custom_response(_req: Request) -> Result<Response> {
+    let res = Response::empty();
+    let html = r#"
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <title>custom response</title>
+    </head>
+    <body>
+        <h1>custom response</h1>
+    </body>
+    </html>"#;
+    let res = res.set_body(full(html));
+    Ok(res)
+}
+
+async fn custom_response2(_req: Request) -> Result<Response> {
+    let html = r#"
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <title>custom response2</title>
+    </head>
+    <body>
+        <h1>custom response2</h1>
+    </body>
+    </html>"#;
+    Ok(html.into())
+}

--- a/silent/src/handler/handler_trait.rs
+++ b/silent/src/handler/handler_trait.rs
@@ -7,7 +7,5 @@ pub trait Handler: Send + Sync + 'static {
         true
     }
 
-    async fn call(&self, _req: Request) -> Result<Response> {
-        Ok(Response::empty())
-    }
+    async fn call(&self, _req: Request) -> Result<Response>;
 }

--- a/silent/src/handler/handler_wrapper.rs
+++ b/silent/src/handler/handler_wrapper.rs
@@ -5,6 +5,7 @@ use bytes::Bytes;
 use serde::Serialize;
 use serde_json::Value;
 use std::future::Future;
+use std::sync::Arc;
 
 /// 处理器包装结构体
 /// 包含
@@ -34,6 +35,10 @@ where
             Value::String(value) => Ok(value.into_bytes().into()),
             _ => Ok(serde_json::to_vec(&result)?.into()),
         }
+    }
+
+    pub fn arc(self) -> Arc<Self> {
+        Arc::new(self)
     }
 }
 

--- a/silent/src/handler/handler_wrapper_response.rs
+++ b/silent/src/handler/handler_wrapper_response.rs
@@ -1,0 +1,76 @@
+use crate::handler::handler_trait::Handler;
+use crate::{Request, Response, Result};
+use async_trait::async_trait;
+use std::future::Future;
+use std::sync::Arc;
+
+/// 处理器包装结构体
+/// 包含
+/// 请求类型: Option<Method>
+/// 请求方法: Handler
+/// 其中请求类型可为空，用来定义中间件
+/// 请求方法不可为空，用来定义处理器
+/// 处理器为返回值为 Into<Bytes> + From<Bytes>的异步函数或者闭包函数
+pub struct HandlerWrapperResponse<F> {
+    handler: F,
+}
+
+impl<F, Fut> HandlerWrapperResponse<F>
+where
+    Fut: Future<Output = Result<Response>> + Send + Sync + 'static,
+    F: Fn(Request) -> Fut,
+{
+    pub fn new(handler: F) -> Self {
+        HandlerWrapperResponse { handler }
+    }
+
+    pub async fn handle(&self, req: Request) -> Result<Response> {
+        (self.handler)(req).await
+    }
+
+    pub fn arc(self) -> Arc<Self> {
+        Arc::new(self)
+    }
+}
+
+/// 为HandlerWrapper实现Handler
+#[async_trait]
+impl<F, Fut> Handler for HandlerWrapperResponse<F>
+where
+    Fut: Future<Output = Result<Response>> + Send + Sync + 'static,
+    F: Fn(Request) -> Fut + Send + Sync + 'static,
+{
+    async fn call(&self, req: Request) -> Result<Response> {
+        self.handle(req).await
+    }
+}
+
+impl<F, Fut> From<F> for HandlerWrapperResponse<F>
+where
+    Fut: Future<Output = Result<Response>> + Send + Sync + 'static,
+    F: Fn(Request) -> Fut + Send + Sync + 'static,
+{
+    fn from(handler: F) -> Self {
+        Self { handler }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Request, Result, StatusCode};
+
+    async fn hello_world(_req: Request) -> Result<Response> {
+        Ok(Response::empty())
+    }
+
+    #[tokio::test]
+    async fn handler_wrapper_match_req_works() {
+        let handler_wrapper = HandlerWrapperResponse::new(hello_world);
+        let req = Request::empty();
+        assert!(handler_wrapper.match_req(&req).await);
+        let res = handler_wrapper.call(req).await;
+        assert!(res.is_ok());
+        assert_eq!(res.unwrap().status(), StatusCode::OK);
+    }
+}

--- a/silent/src/handler/mod.rs
+++ b/silent/src/handler/mod.rs
@@ -1,10 +1,12 @@
 /// Handler module
 mod handler_trait;
 mod handler_wrapper;
+mod handler_wrapper_response;
 #[cfg(feature = "static")]
 mod handler_wrapper_static;
 
 pub use handler_trait::Handler;
-pub(crate) use handler_wrapper::HandlerWrapper;
+pub use handler_wrapper::HandlerWrapper;
+pub use handler_wrapper_response::HandlerWrapperResponse;
 #[cfg(feature = "static")]
 pub use handler_wrapper_static::static_handler;

--- a/silent/src/lib.rs
+++ b/silent/src/lib.rs
@@ -20,7 +20,7 @@ pub use crate::middleware::MiddleWareHandler;
 pub use error::SilentError;
 pub use error::SilentResult as Result;
 pub use handler::Handler;
-pub(crate) use handler::HandlerWrapper;
+pub use handler::{HandlerWrapper, HandlerWrapperResponse};
 pub use hyper::{header, Method, StatusCode};
 
 pub mod prelude {
@@ -31,6 +31,7 @@ pub mod prelude {
     #[cfg(feature = "static")]
     pub use crate::handler::static_handler;
     pub use crate::handler::Handler;
+    pub use crate::handler::{HandlerWrapper, HandlerWrapperResponse};
     pub use crate::log::*;
     pub use crate::middleware::MiddleWareHandler;
     #[cfg(feature = "ws")]

--- a/silent/src/route/handler_append.rs
+++ b/silent/src/route/handler_append.rs
@@ -16,6 +16,7 @@ use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
 pub trait HandlerGetter {
     fn get_handler_mut(&mut self) -> &mut HashMap<Method, Arc<dyn Handler>>;
     fn insert_handler(self, method: Method, handler: Arc<dyn Handler>) -> Self;
+    fn handler(self, method: Method, handler: Arc<dyn Handler>) -> Self;
 }
 
 pub trait HandlerAppend<F, T, Fut>: HandlerGetter
@@ -109,6 +110,11 @@ impl HandlerGetter for Route {
     }
     fn insert_handler(mut self, method: Method, handler: Arc<dyn Handler>) -> Self {
         self.handler.insert(method, handler);
+        self
+    }
+
+    fn handler(mut self, method: Method, handler: Arc<dyn Handler>) -> Self {
+        self.get_handler_mut().insert(method, handler);
         self
     }
 }


### PR DESCRIPTION
# Route路由添加Handler方式优化
增加 `fn handler(self, method: Method, handler: Arc<dyn Handler>) -> Self` 方法
# Handler简化
1. handler处理机制优化
增加直接返回为Response的封装
[详细示例(examples/custom_response)](https://github.com/hubertshelley/silent/blob/main/examples/custom_response/src/main.rs)
2. 增加定制Handler
[详细示例(examples/custom_handler)](https://github.com/hubertshelley/silent/blob/main/examples/custom_handler/src/main.rs)
