### PR TITLE
refactor(response) : response优化重构

### DIFF
--- a/examples/exception_handler/src/main.rs
+++ b/examples/exception_handler/src/main.rs
@@ -14,7 +14,7 @@ fn main() {
         .route()
         .set_exception_handler(|e, _| async move {
             Exception {
-                code: e.status_code().as_u16(),
+                code: e.status().as_u16(),
                 msg: e.to_string(),
             }
         });

--- a/silent/src/core/adapt.rs
+++ b/silent/src/core/adapt.rs
@@ -64,7 +64,7 @@ impl<B: Body> ResponseAdapt for HyperResponse<B> {
     fn tran_from_response(res: Response<B>) -> Self {
         #[cfg(feature = "cookie")]
         let Response {
-            status_code,
+            status,
             headers,
             body,
             cookies,
@@ -74,7 +74,7 @@ impl<B: Body> ResponseAdapt for HyperResponse<B> {
         } = res;
         #[cfg(not(feature = "cookie"))]
         let Response {
-            status_code,
+            status,
             headers,
             body,
             version,
@@ -93,7 +93,7 @@ impl<B: Body> ResponseAdapt for HyperResponse<B> {
             }
         }
         // Default to a 404 if no response code was set
-        *res.status_mut() = status_code;
+        *res.status_mut() = status;
 
         res
     }

--- a/silent/src/core/response.rs
+++ b/silent/src/core/response.rs
@@ -4,10 +4,8 @@ use std::fmt::{Display, Formatter};
 use bytes::Bytes;
 #[cfg(feature = "cookie")]
 use cookie::{Cookie, CookieJar};
-use http::response::Parts;
 use http::{Extensions, Version};
 use http_body::{Body, SizeHint};
-use http_body_util::BodyExt;
 use serde::Serialize;
 use serde_json::Value;
 
@@ -32,51 +30,6 @@ pub struct Response<B: Body = ResBody> {
     pub(crate) cookies: CookieJar,
     pub(crate) extensions: Extensions,
     pub(crate) configs: Configs,
-}
-
-impl Response {
-    #[cfg(feature = "grpc")]
-    /// 合并axum响应
-    #[inline]
-    pub async fn merge_axum(&mut self, res: axum::response::Response) {
-        let (parts, body) = res.into_parts();
-        let Parts {
-            status,
-            headers,
-            extensions,
-            version,
-            ..
-        } = parts;
-        self.status = status;
-        self.version = version;
-        self.headers.extend(headers);
-        self.extensions.extend(extensions);
-        self.body = ResBody::Boxed(Box::pin(body.map_err(|e| e.into())));
-    }
-
-    /// 合并hyper响应
-    #[inline]
-    pub fn merge_hyper<B>(&mut self, hyper_res: hyper::Response<B>)
-    where
-        B: Into<ResBody>,
-    {
-        let (
-            Parts {
-                status,
-                headers,
-                extensions,
-                version,
-                ..
-            },
-            body,
-        ) = hyper_res.into_parts();
-
-        self.status = status;
-        self.headers.extend(headers);
-        self.extensions.extend(extensions);
-        self.version = version;
-        self.body = body.into();
-    }
 }
 
 impl fmt::Debug for Response {

--- a/silent/src/core/response.rs
+++ b/silent/src/core/response.rs
@@ -21,7 +21,7 @@ use std::fmt::{Display, Formatter};
 /// ```
 pub struct Response<B: Body = ResBody> {
     /// The HTTP status code.
-    pub(crate) status_code: StatusCode,
+    pub(crate) status: StatusCode,
     /// The HTTP version.
     pub(crate) version: Version,
     /// The HTTP headers.
@@ -46,7 +46,7 @@ impl Response {
             version,
             ..
         } = parts;
-        self.status_code = status;
+        self.status = status;
         self.version = version;
         self.headers.extend(headers);
         self.extensions.extend(extensions);
@@ -70,7 +70,7 @@ impl Response {
             body,
         ) = hyper_res.into_parts();
 
-        self.status_code = status;
+        self.status = status;
         self.headers.extend(headers);
         self.extensions.extend(extensions);
         self.version = version;
@@ -81,11 +81,7 @@ impl Response {
 impl fmt::Debug for Response {
     #[inline]
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        writeln!(
-            f,
-            "{:?} {}\n{:?}",
-            self.version, self.status_code, self.headers
-        )
+        writeln!(f, "{:?} {}\n{:?}", self.version, self.status, self.headers)
     }
 }
 
@@ -100,7 +96,7 @@ impl Response {
     /// 创建空响应体
     pub fn empty() -> Self {
         Self {
-            status_code: StatusCode::OK,
+            status: StatusCode::OK,
             headers: HeaderMap::new(),
             version: Version::default(),
             body: ResBody::None,
@@ -113,12 +109,12 @@ impl Response {
     /// 设置响应状态
     #[inline]
     pub fn set_status(&mut self, status: StatusCode) {
-        self.status_code = status;
+        self.status = status;
     }
     /// 包含响应状态
     #[inline]
     pub fn with_status(mut self, status: StatusCode) -> Self {
-        self.status_code = status;
+        self.status = status;
         self
     }
     /// 设置响应body
@@ -162,7 +158,7 @@ impl Response {
     /// 设置响应重定向
     pub fn redirect(url: &str) -> Result<Self> {
         let mut res = Self::empty();
-        res.status_code = StatusCode::MOVED_PERMANENTLY;
+        res.status = StatusCode::MOVED_PERMANENTLY;
         res.headers.insert(
             header::LOCATION,
             url.parse().map_err(|e| {
@@ -260,7 +256,7 @@ impl Response {
         res.cookies.delta().for_each(|cookie| {
             self.cookies.add(cookie.clone());
         });
-        self.status_code = res.status_code;
+        self.status = res.status;
         self.extensions.extend(res.extensions);
         self.set_body(res.body);
     }
@@ -269,7 +265,7 @@ impl Response {
     /// move response to from another response
     pub fn copy_from_response(&mut self, res: Response) {
         self.headers.extend(res.headers);
-        self.status_code = res.status_code;
+        self.status = res.status;
         self.extensions.extend(res.extensions);
         self.set_body(res.body);
     }

--- a/silent/src/error/exception_handler_wrapper.rs
+++ b/silent/src/error/exception_handler_wrapper.rs
@@ -68,7 +68,7 @@ mod tests {
                     configs
                 )
                 .await
-                .status_code,
+                .status,
             StatusCode::OK
         );
     }

--- a/silent/src/error/mod.rs
+++ b/silent/src/error/mod.rs
@@ -84,7 +84,7 @@ impl SilentError {
     pub fn business_error(code: StatusCode, msg: String) -> Self {
         Self::BusinessError { code, msg }
     }
-    pub fn status_code(&self) -> StatusCode {
+    pub fn status(&self) -> StatusCode {
         match self {
             Self::BusinessError { code, .. } => *code,
             Self::SerdeDeError(_) => StatusCode::UNPROCESSABLE_ENTITY,
@@ -108,7 +108,7 @@ impl SilentError {
 impl From<SilentError> for Response {
     fn from(value: SilentError) -> Self {
         let mut res = Response::empty();
-        res.set_status(value.status_code());
+        res.set_status(value.status());
         if serde_json::from_str::<Value>(&value.message()).is_ok() {
             res.set_typed_header(ContentType::json());
         }
@@ -141,7 +141,7 @@ mod tests {
         };
         let err = SilentError::business_error_obj(StatusCode::BAD_REQUEST, res_body);
         let mut res: Response = err.into();
-        assert_eq!(res.status_code, StatusCode::BAD_REQUEST);
+        assert_eq!(res.status, StatusCode::BAD_REQUEST);
         println!("{:#?}", res.headers);
         println!(
             "{:#?}",

--- a/silent/src/grpc/handler.rs
+++ b/silent/src/grpc/handler.rs
@@ -1,3 +1,4 @@
+use super::utils::merge_axum;
 use crate::grpc::service::GrpcService;
 use crate::{Handler, Response, SilentError};
 use async_trait::async_trait;
@@ -55,7 +56,7 @@ impl Handler for GrpcHandler {
                 )
             })?;
             let mut res = Response::empty();
-            res.merge_axum(axum_res).await;
+            merge_axum(&mut res, axum_res).await;
 
             Ok(res)
         }

--- a/silent/src/grpc/mod.rs
+++ b/silent/src/grpc/mod.rs
@@ -1,5 +1,6 @@
 mod handler;
 mod service;
+mod utils;
 // mod stream;
 
 pub use handler::GrpcHandler;

--- a/silent/src/grpc/utils.rs
+++ b/silent/src/grpc/utils.rs
@@ -1,0 +1,23 @@
+use crate::prelude::ResBody;
+use crate::Response;
+use http::response::Parts;
+use http_body_util::BodyExt;
+
+#[cfg(feature = "grpc")]
+/// 合并axum响应
+#[inline]
+pub async fn merge_axum(res: &mut Response, axum_res: axum::response::Response) {
+    let (parts, body) = axum_res.into_parts();
+    let Parts {
+        status,
+        headers,
+        extensions,
+        version,
+        ..
+    } = parts;
+    res.status = status;
+    res.version = version;
+    res.headers.extend(headers);
+    res.extensions.extend(extensions);
+    res.body = ResBody::Boxed(Box::pin(body.map_err(|e| e.into())));
+}

--- a/silent/src/handler/handler_wrapper_static.rs
+++ b/silent/src/handler/handler_wrapper_static.rs
@@ -1,10 +1,10 @@
-use crate::prelude::stream_body;
-use crate::{Handler, Request, Response, SilentError, StatusCode};
 use async_trait::async_trait;
 use futures_util::StreamExt;
-use mime::Mime;
 use tokio::fs::File;
 use tokio_util::io::ReaderStream;
+
+use crate::prelude::stream_body;
+use crate::{Handler, Request, Response, SilentError, StatusCode};
 
 struct HandlerWrapperStatic {
     path: String,
@@ -63,14 +63,16 @@ pub fn static_handler(path: &str) -> impl Handler {
 
 #[cfg(test)]
 mod tests {
-    use super::HandlerWrapperStatic;
+    use bytes::Bytes;
+    use http_body_util::BodyExt;
+
     use crate::prelude::*;
     use crate::Handler;
     use crate::Request;
     use crate::SilentError;
     use crate::StatusCode;
-    use bytes::Bytes;
-    use http_body_util::BodyExt;
+
+    use super::HandlerWrapperStatic;
 
     static CONTENT: &str = r#"<!DOCTYPE html>
 <html>
@@ -110,7 +112,7 @@ mod tests {
         req.set_path_params("path".to_owned(), PathParam::Path("index.html".to_string()));
         let mut res = handler.call(req).await.unwrap();
         clean_static(path);
-        assert_eq!(res.status_code, StatusCode::OK);
+        assert_eq!(res.status, StatusCode::OK);
         assert_eq!(
             res.body.frame().await.unwrap().unwrap().data_ref().unwrap(),
             &Bytes::from(CONTENT)
@@ -126,7 +128,7 @@ mod tests {
         req.set_path_params("path".to_owned(), PathParam::Path("".to_string()));
         let mut res = handler.call(req).await.unwrap();
         clean_static(path);
-        assert_eq!(res.status_code, StatusCode::OK);
+        assert_eq!(res.status, StatusCode::OK);
         assert_eq!(
             res.body.frame().await.unwrap().unwrap().data_ref().unwrap(),
             &Bytes::from(CONTENT)

--- a/silent/src/route/root.rs
+++ b/silent/src/route/root.rs
@@ -244,7 +244,7 @@ impl RootRoute {
                     method,
                     url,
                     http_version,
-                    res.status_code.as_u16(),
+                    res.status.as_u16(),
                     res.content_length().lower(),
                     req_time.num_nanoseconds().unwrap_or(0) as f64 / 1000000.0
                 );
@@ -257,7 +257,7 @@ impl RootRoute {
                     method,
                     url,
                     http_version,
-                    e.status_code().as_u16(),
+                    e.status().as_u16(),
                     0,
                     req_time.num_nanoseconds().unwrap_or(0) as f64 / 1000000.0,
                     e.to_string()


### PR DESCRIPTION
1. 调整response中的status_code为status
2. ResBody调整，去除Boxed中的Sync属性，增加适应范围
3. response中大部分实现方法调整为范型实现
4. 迁移response中合成axum响应方法到grpc模块中
5. 修复一次性grpc请求server closed the stream without sending trailers异常